### PR TITLE
ブログアプリのフロントエンドで記事IDをbodyではなくURLで指定できるようにする

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -112,9 +112,9 @@ app.post('/admin/articles', async (req, res) => {
 // APIのURL http://localhost:8000/admin/articles/:id
 // 作成が完了したら http://localhost:3000/admin/update/1 にアクセスして確認してみましょう！
 app.put('/admin/articles/:id', async (req, res) => {
-  const { articleId, title, content, category, status } = req.body;
+  const { title, content, category, status } = req.body;
 
-  const id = Number(articleId);
+  const id = Number(req.params.id);
   if (Number.isNaN(id)) {
     res.status(400).json({ error: { message: 'ID 形式が不正な形式となっています' } });
     return;
@@ -154,9 +154,7 @@ app.put('/admin/articles/:id', async (req, res) => {
 // APIのURL http://localhost:8000/admin/articles/:id
 // 作成が完了したら http://localhost:3000/admin などの削除ボタンをクリックしてみよう
 app.delete('/admin/articles/:id', async (req, res) => {
-  const { articleId } = req.body;
-
-  const id = Number(articleId);
+  const id = Number(req.params.id);
   if (Number.isNaN(id)) {
     res.status(400).json({ error: { message: 'ID 形式が不正な形式となっています' } });
     return;

--- a/src/app/(unique)/admin/hooks/index.ts
+++ b/src/app/(unique)/admin/hooks/index.ts
@@ -6,7 +6,7 @@ export const useHooks = () => {
   const { deleteError, deleteStudyError, isDeleting, deleteArticle } = useDeleteArticle();
 
   const handleDelete = async (id: string) => {
-    await deleteArticle({ articleId: id });
+    await deleteArticle(undefined, { url: `http://localhost:8000/admin/articles/${id}` });
     await refetch();
   };
 

--- a/src/app/(unique)/admin/update/[id]/components/article-actions/index.tsx
+++ b/src/app/(unique)/admin/update/[id]/components/article-actions/index.tsx
@@ -14,7 +14,7 @@ export const MyArticleActions = ({ onClickDelete, isDeleting }: Props) => {
     <div className={styles.root}>
       <div>
         <MyButton asChild>
-          <Link href="/">一覧に戻る</Link>
+          <Link href="/admin">一覧に戻る</Link>
         </MyButton>
       </div>
       <div>

--- a/src/app/(unique)/admin/update/[id]/hooks/use-delete-article.ts
+++ b/src/app/(unique)/admin/update/[id]/hooks/use-delete-article.ts
@@ -6,10 +6,10 @@ import { useDeleteArticleApi } from '~/features/article/hooks/use-delete-article
 export const useDeleteArticle = (id: string) => {
   const router = useRouter();
 
-  const { success, error, studyError, isDeleting, deleteArticle } = useDeleteArticleApi();
+  const { success, error, studyError, isDeleting, deleteArticle } = useDeleteArticleApi(id);
 
   const handleDelete = () => {
-    deleteArticle({ articleId: id });
+    deleteArticle();
   };
 
   useEffect(() => {

--- a/src/app/(unique)/admin/update/[id]/hooks/use-update-article.ts
+++ b/src/app/(unique)/admin/update/[id]/hooks/use-update-article.ts
@@ -7,10 +7,10 @@ import { ArticleCategory, ArticleStatus } from '~/features/article/ui-models/art
 export const useUpdateArticle = (id: string) => {
   const router = useRouter();
 
-  const { success, error, studyError, isUpdating, updateArticle } = useUpdateArticleApi();
+  const { success, error, studyError, isUpdating, updateArticle } = useUpdateArticleApi(id);
 
   const handleSubmit = (title: string, content: string, category: ArticleCategory, status: ArticleStatus) => {
-    updateArticle({ articleId: id, title, content, category, status });
+    updateArticle({ title, content, category, status });
   };
 
   useEffect(() => {

--- a/src/components/surface/navigations/tabs/index.tsx
+++ b/src/components/surface/navigations/tabs/index.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import styles from './styles.module.css';
 
 type TabItem = {
@@ -23,6 +21,7 @@ export const MyTabs = ({ items, value, onChange }: Props) => {
       <div className={styles.tabs} role="tablist">
         {items.map((item) => (
           <button
+            key={item.value}
             className={styles.tab}
             role="tab"
             aria-selected={item.value === value}

--- a/src/features/app/hooks/use-mutate-fetch.ts
+++ b/src/features/app/hooks/use-mutate-fetch.ts
@@ -5,7 +5,7 @@ type ErrorResponse = {
   message: string;
 };
 
-export const useMutateFetch = <T>(url: string, method: string) => {
+export const useMutateFetch = <T>(method: string, initialOption?: { url: string }) => {
   const [data, setData] = useState<T | null>();
   const [error, setError] = useState<ErrorResponse | null>();
   const [studyError, setStudyError] = useState<ErrorResponse | null>();
@@ -36,7 +36,7 @@ export const useMutateFetch = <T>(url: string, method: string) => {
     setIsLoading(true);
   };
 
-  const mutate = async (values?) => {
+  const mutate = async (values?, options?: { url?: string }) => {
     const body = JSON.stringify(values);
 
     setStatesWhenStartFetching();
@@ -46,6 +46,15 @@ export const useMutateFetch = <T>(url: string, method: string) => {
       headers: { 'Content-Type': 'application/json' },
       mode: 'cors',
     };
+
+    const url = options?.url || initialOption?.url;
+
+    if (!url) {
+      setError({
+        message: 'URLが指定されていません。',
+      });
+      return;
+    }
 
     return await fetch(url, { ...configs, body })
       .then(async (res) => {

--- a/src/features/app/hooks/use-mutate-fetch.ts
+++ b/src/features/app/hooks/use-mutate-fetch.ts
@@ -5,7 +5,7 @@ type ErrorResponse = {
   message: string;
 };
 
-export const useMutateFetch = <T>(method: string, initialOption?: { url: string }) => {
+export const useMutateFetch = <T>(method: string, initialOptions?: { url?: string }) => {
   const [data, setData] = useState<T | null>();
   const [error, setError] = useState<ErrorResponse | null>();
   const [studyError, setStudyError] = useState<ErrorResponse | null>();
@@ -47,7 +47,7 @@ export const useMutateFetch = <T>(method: string, initialOption?: { url: string 
       mode: 'cors',
     };
 
-    const url = options?.url || initialOption?.url;
+    const url = options?.url || initialOptions?.url;
 
     if (!url) {
       setError({

--- a/src/features/article/hooks/use-create-article-api.ts
+++ b/src/features/article/hooks/use-create-article-api.ts
@@ -7,10 +7,9 @@ type ApiResponseData = { id: string };
 export const useCreateArticleApi = () => {
   const [success, setSuccess] = useState<boolean | null>(null);
 
-  const { data, error, studyError, isLoading, mutate } = useMutateFetch<ApiResponseData>(
-    'http://localhost:8000/admin/articles',
-    'post',
-  );
+  const { data, error, studyError, isLoading, mutate } = useMutateFetch<ApiResponseData>('post', {
+    url: 'http://localhost:8000/admin/articles',
+  });
 
   useEffect(() => {
     if (!data) return;

--- a/src/features/article/hooks/use-delete-article-api.ts
+++ b/src/features/article/hooks/use-delete-article-api.ts
@@ -4,11 +4,11 @@ import { useMutateFetch } from '~/features/app/hooks/use-mutate-fetch';
 
 type ApiResponseData = { id: string };
 
-export const useDeleteArticleApi = (id: string) => {
+export const useDeleteArticleApi = (id?: string) => {
   const [success, setSuccess] = useState<boolean | null>(null);
 
   const { data, error, studyError, isLoading, mutate } = useMutateFetch<ApiResponseData>('delete', {
-    url: `http://localhost:8000/admin/articles/${id}`,
+    url: id ? `http://localhost:8000/admin/articles/${id}` : undefined,
   });
 
   useEffect(() => {

--- a/src/features/article/hooks/use-delete-article-api.ts
+++ b/src/features/article/hooks/use-delete-article-api.ts
@@ -4,13 +4,12 @@ import { useMutateFetch } from '~/features/app/hooks/use-mutate-fetch';
 
 type ApiResponseData = { id: string };
 
-export const useDeleteArticleApi = () => {
+export const useDeleteArticleApi = (id: string) => {
   const [success, setSuccess] = useState<boolean | null>(null);
 
-  const { data, error, studyError, isLoading, mutate } = useMutateFetch<ApiResponseData>(
-    `http://localhost:8000/admin/articles/:id`,
-    'delete',
-  );
+  const { data, error, studyError, isLoading, mutate } = useMutateFetch<ApiResponseData>('delete', {
+    url: `http://localhost:8000/admin/articles/${id}`,
+  });
 
   useEffect(() => {
     if (!data) return;

--- a/src/features/article/hooks/use-update-article-api.ts
+++ b/src/features/article/hooks/use-update-article-api.ts
@@ -4,13 +4,12 @@ import { useMutateFetch } from '~/features/app/hooks/use-mutate-fetch';
 
 type ApiResponseData = { id: string };
 
-export const useUpdateArticleApi = () => {
+export const useUpdateArticleApi = (id: string) => {
   const [success, setSuccess] = useState<boolean | null>(null);
 
-  const { data, error, studyError, isLoading, mutate } = useMutateFetch<ApiResponseData>(
-    `http://localhost:8000/admin/articles/:id`,
-    'put',
-  );
+  const { data, error, studyError, isLoading, mutate } = useMutateFetch<ApiResponseData>('put', {
+    url: `http://localhost:8000/admin/articles/${id}`,
+  });
 
   useEffect(() => {
     if (!data) return;


### PR DESCRIPTION
## ブログアプリのフロントエンドで記事IDをbodyではなくURLで指定できるようにする
https://www.notion.so/ID-body-URL-18580a811cab45b5a1533f0fcdf1b37d?pvs=4

## 作業内容
bodyで指定していた記事IDを URL で指定するようにしました。